### PR TITLE
do not change KaTeX styles

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1,4 +1,4 @@
-* {
+*:not(.katex *) {
     box-sizing: border-box;
     margin: 0;
     padding: 0;

--- a/assets/css/tag-box.css
+++ b/assets/css/tag-box.css
@@ -10,7 +10,7 @@
     --tag-count-text-color: #c0c0c0;
 }
 
-.tag {
+.tag:not(.katex .tag) {
     display: flex;
 }
 


### PR DESCRIPTION
changing KaTeX styles may break equations.
- changing font family break \neq
- .tag was selecting tags to equations and making their display flex-box which broke equation numbering positioning